### PR TITLE
Fix. add internal default contact on V>13

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -54,7 +54,13 @@ if ($action == 'addcontact')
     if ($id > 0)
     {
     	$contactid = (GETPOST('userid','int') ? GETPOST('userid','int') : GETPOST('contactid','int'));
-  		$result = $object->add_contact($contactid, ((DOL_VERSION < 13) ? GETPOST('type') : GETPOST('typecontact')), GETPOST('source'));
+  		if(DOL_VERSION < 13 || !empty(GETPOST('type','int'))){
+    			$typecontact = GETPOST('type','int');
+		}else{
+    			$typecontact = GETPOST('typecontact','int');
+    		}	
+
+  		$result = $object->add_contact($contactid, $typecontact, GETPOST('source'));
     }
 
 	if ($result >= 0)


### PR DESCRIPTION
Beacause internal select type contact is still called type while external select contact type is called typecontact This is the same at dolibarr V16

Source topic on dolibarr forum : https://www.dolibarr.fr/forum/t/contact-par-defaut-qui-nest-pas-lie-au-tiers/42567/5